### PR TITLE
Add lightstyle interpolation (from Ironwail)

### DIFF
--- a/Quake/gl_rlight.c
+++ b/Quake/gl_rlight.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 int r_dlightframecount;
 
 extern cvar_t r_flatlightstyles; // johnfitz
+extern cvar_t r_lerplightstyles;
 
 /*
 ==================
@@ -34,12 +35,13 @@ R_AnimateLight
 */
 void R_AnimateLight (void)
 {
-	int i, j, k;
+	int i, j, k, n;
+	double f;
 
 	//
 	// light animations
 	// 'm' is normal light, 'a' is no light, 'z' is double bright
-	i = (int)(cl.time * 10);
+	i = f = cl.time * 10;
 	for (j = 0; j < MAX_LIGHTSTYLES; j++)
 	{
 		if (!cl_lightstyle[j].length)
@@ -49,15 +51,17 @@ void R_AnimateLight (void)
 		}
 		// johnfitz -- r_flatlightstyles
 		if (r_flatlightstyles.value == 2)
-			k = cl_lightstyle[j].peak - 'a';
+			k = n = cl_lightstyle[j].peak - 'a';
 		else if (r_flatlightstyles.value == 1)
-			k = cl_lightstyle[j].average - 'a';
+			k = n = cl_lightstyle[j].average - 'a';
 		else
 		{
-			k = i % cl_lightstyle[j].length;
-			k = cl_lightstyle[j].map[k] - 'a';
+			k = cl_lightstyle[j].map[ i    % cl_lightstyle[j].length] - 'a';
+			n = cl_lightstyle[j].map[(i+1) % cl_lightstyle[j].length] - 'a';
 		}
-		d_lightstylevalue[j] = k * 22;
+		if (!r_lerplightstyles.value || r_lerplightstyles.value < 2 && abs(n - k) >= ('m' - 'a') / 2)
+			n = k;
+		d_lightstylevalue[j] = (k + (n - k) * (f - i)) * 22;
 		// johnfitz
 	}
 }

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -82,6 +82,7 @@ cvar_t gl_nocolors = {"gl_nocolors", "0", CVAR_NONE};
 cvar_t r_clearcolor = {"r_clearcolor", "2", CVAR_ARCHIVE};
 cvar_t r_fastclear = {"r_fastclear", "1", CVAR_ARCHIVE};
 cvar_t r_flatlightstyles = {"r_flatlightstyles", "0", CVAR_NONE};
+cvar_t r_lerplightstyles = { "r_lerplightstyles", "1", CVAR_ARCHIVE }; // 0=off; 1=skip abrupt transitions; 2=always lerp
 cvar_t gl_fullbrights = {"gl_fullbrights", "1", CVAR_ARCHIVE};
 cvar_t gl_farclip = {"gl_farclip", "16384", CVAR_ARCHIVE};
 cvar_t r_oldskyleaf = {"r_oldskyleaf", "0", CVAR_NONE};

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -38,6 +38,7 @@ cvar_t r_lodbias = {"r_lodbias", "1", CVAR_ARCHIVE};
 extern cvar_t r_clearcolor;
 extern cvar_t r_fastclear;
 extern cvar_t r_flatlightstyles;
+extern cvar_t r_lerplightstyles;
 extern cvar_t gl_fullbrights;
 extern cvar_t gl_farclip;
 extern cvar_t r_waterquality;
@@ -2908,6 +2909,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_waterwarp);
 	Cvar_RegisterVariable (&r_waterwarpcompute);
 	Cvar_RegisterVariable (&r_flatlightstyles);
+	Cvar_RegisterVariable (&r_lerplightstyles);
 	Cvar_RegisterVariable (&r_oldskyleaf);
 	Cvar_RegisterVariable (&r_drawworld);
 	Cvar_RegisterVariable (&r_showtris);


### PR DESCRIPTION
Controlled by new cvar r_lerplightstyles:
0 = no interpolation
1 = only interpolate smaller changes (this will keep the flickering light in e1m1 instant)
2 = always interpolate
Default value is 1.